### PR TITLE
enable dwmapi to use app_id

### DIFF
--- a/internal/ula-client/core/core_type.go
+++ b/internal/ula-client/core/core_type.go
@@ -20,6 +20,7 @@ package core
 type CAVsurface struct {
 	AppName    string /* who is it created by */
 	VID        int
+	AppID      string
 	PixelW     int
 	PixelH     int
 	PsrcX      int

--- a/internal/ula-client/readclusterapp/read_cluster_app.go
+++ b/internal/ula-client/readclusterapp/read_cluster_app.go
@@ -33,18 +33,19 @@ const (
 )
 
 type caCfgInitialLayoutVsurface struct {
-	VID        int  `json:"VID"`
-	PixelW     int  `json:"pixel_w"`
-	PixelH     int  `json:"pixel_h"`
-	PsrcX      int  `json:"psrc_x"`
-	PsrcY      int  `json:"psrc_y"`
-	PsrcW      int  `json:"psrc_w"`
-	PsrcH      int  `json:"psrc_h"`
-	VdstX      int  `json:"vdst_x"`
-	VdstY      int  `json:"vdst_y"`
-	VdstW      int  `json:"vdst_w"`
-	VdstH      int  `json:"vdst_h"`
-	Visibility *int `json:"visibility"`
+	VID        int    `json:"VID"`
+	AppID      string `json:"AppID"`
+	PixelW     int    `json:"pixel_w"`
+	PixelH     int    `json:"pixel_h"`
+	PsrcX      int    `json:"psrc_x"`
+	PsrcY      int    `json:"psrc_y"`
+	PsrcW      int    `json:"psrc_w"`
+	PsrcH      int    `json:"psrc_h"`
+	VdstX      int    `json:"vdst_x"`
+	VdstY      int    `json:"vdst_y"`
+	VdstW      int    `json:"vdst_w"`
+	VdstH      int    `json:"vdst_h"`
+	Visibility *int   `json:"visibility"`
 }
 
 type caCfgInitialLayoutVLayer struct {
@@ -169,6 +170,7 @@ func newCAVLayoutFromCfg(appDir string) (*core.CALayout, error) {
 			vsurf := core.CAVsurface{
 				AppName:    appName,
 				VID:        s.VID,
+				AppID:      s.AppID,
 				PixelW:     s.PixelW,
 				PixelH:     s.PixelH,
 				PsrcX:      s.PsrcX,

--- a/internal/ula-client/ulacommgen/ula_comm_generator.go
+++ b/internal/ula-client/ulacommgen/ula_comm_generator.go
@@ -30,6 +30,7 @@ func convCAVSurface2UPIVsurface(csurf *core.CAVsurface) *UPIVsurface {
 	usurf := new(UPIVsurface)
 
 	usurf.VID = csurf.VID
+	usurf.AppID = csurf.AppID
 
 	usurf.PixelW = csurf.PixelW
 	usurf.PixelH = csurf.PixelH

--- a/internal/ula-client/ulacommgen/ula_comm_generator_protocol.go
+++ b/internal/ula-client/ulacommgen/ula_comm_generator_protocol.go
@@ -19,18 +19,19 @@ package ulacommgen
 
 /*  Ula Protocol for Initial VSurface */
 type UPIVsurface struct {
-	VID        int  `json:"VID"`
-	PixelW     int  `json:"pixel_w"`
-	PixelH     int  `json:"pixel_h"`
-	PsrcX      int  `json:"psrc_x"`
-	PsrcY      int  `json:"psrc_y"`
-	PsrcW      int  `json:"psrc_w"`
-	PsrcH      int  `json:"psrc_h"`
-	VdstX      int  `json:"vdst_x"`
-	VdstY      int  `json:"vdst_y"`
-	VdstW      int  `json:"vdst_w"`
-	VdstH      int  `json:"vdst_h"`
-	Visibility *int `json:"visibility"`
+	VID        int    `json:"VID"`
+	AppID      string `json:"AppID"`
+	PixelW     int    `json:"pixel_w"`
+	PixelH     int    `json:"pixel_h"`
+	PsrcX      int    `json:"psrc_x"`
+	PsrcY      int    `json:"psrc_y"`
+	PsrcW      int    `json:"psrc_w"`
+	PsrcH      int    `json:"psrc_h"`
+	VdstX      int    `json:"vdst_x"`
+	VdstY      int    `json:"vdst_y"`
+	VdstW      int    `json:"vdst_w"`
+	VdstH      int    `json:"vdst_h"`
+	Visibility *int   `json:"visibility"`
 }
 
 /*  Ula Protocol for Initial Vlayer */

--- a/internal/ula-node/common_type.go
+++ b/internal/ula-node/common_type.go
@@ -79,7 +79,7 @@ func (rdsp *RealDisplay) Dup() *RealDisplay {
 type PixelSurface struct {
 	ParentVID int
 	VID       int
-	AppID  string
+	AppID     string
 
 	PixelW int
 	PixelH int


### PR DESCRIPTION
When the app_id is set in dwm_initial_layout.json, ula-node can retrieve it and transfer it to /tmp/uhmi-agl-wm_sock.