### PR TITLE
ulamulticonn: Exclusive control of resources

### DIFF
--- a/internal/ula-client/ulamulticonn/ula_multi_conn.go
+++ b/internal/ula-client/ulamulticonn/ula_multi_conn.go
@@ -156,8 +156,11 @@ func handleConnectTarget(ums *UlaMultiConnector, addr string, sendChan chan stri
 	}
 	defer conn.Close()
 
+	Mutex.Lock()
 	ums.sendChans = append(ums.sendChans, sendChan)
 	ums.respChans = append(ums.respChans, respChan)
+	Mutex.Unlock()
+
 	wg.Done()
 	for {
 		select {


### PR DESCRIPTION
Add a mutex to handleConnectTarget function in ula_multi_conn.go to avoid multiple go routines from using a specific resource at the same time.